### PR TITLE
fix: convert relative blog post URLs to absolute URLs

### DIFF
--- a/.github/workflows/blog-post.yml
+++ b/.github/workflows/blog-post.yml
@@ -14,3 +14,4 @@ jobs:
         with:
           max_post_count: 10
           feed_list: "https://bruno.verachten.fr/feed.xml"
+          feed_base_url: "https://bruno.verachten.fr"

--- a/.github/workflows/forced_workflow.yml
+++ b/.github/workflows/forced_workflow.yml
@@ -10,3 +10,4 @@ jobs:
         with:
           max_post_count: 10
           feed_list: "https://bruno.verachten.fr/feed.xml"
+          feed_base_url: "https://bruno.verachten.fr"


### PR DESCRIPTION
## Summary
- Fixes 404 errors when clicking blog post links in profile README
- Adds `feed_base_url` parameter to both blog-post workflow configurations

## Problem
Blog post links in README.md were using relative paths (e.g., `/2025/10/30/...`) which GitHub interpreted as repository paths instead of external links to bruno.verachten.fr, resulting in 404 errors.

## Solution
Configured the `blog-post-workflow` action with `feed_base_url: "https://bruno.verachten.fr"` to convert relative RSS feed URLs to absolute URLs.

## Testing
After merging, the next workflow run will update README.md with absolute URLs. Can also manually trigger `forced_workflow.yml` to test immediately.