### PR TITLE
fix: use template parameter to create absolute blog URLs

### DIFF
--- a/.github/workflows/blog-post.yml
+++ b/.github/workflows/blog-post.yml
@@ -14,4 +14,4 @@ jobs:
         with:
           max_post_count: 10
           feed_list: "https://bruno.verachten.fr/feed.xml"
-          feed_base_url: "https://bruno.verachten.fr"
+          template: "- [$title](https://bruno.verachten.fr$url)"

--- a/.github/workflows/forced_workflow.yml
+++ b/.github/workflows/forced_workflow.yml
@@ -10,4 +10,4 @@ jobs:
         with:
           max_post_count: 10
           feed_list: "https://bruno.verachten.fr/feed.xml"
-          feed_base_url: "https://bruno.verachten.fr"
+          template: "- [$title](https://bruno.verachten.fr$url)"


### PR DESCRIPTION
## Summary
- Fixes the previous attempt that used invalid `feed_base_url` parameter
- Uses the correct `template` parameter to prepend base URL to blog post links

## Problem
The previous fix (PR #4) used `feed_base_url` which is not a valid parameter for the blog-post-workflow action, causing the workflow to ignore it and continue generating relative URLs.

## Solution
Use the `template` parameter with value `"- [$title](https://bruno.verachten.fr$url)"` to prepend the base URL to the relative `$url` value from the RSS feed.

## Testing
After merging, manually trigger `forced_workflow.yml` to verify URLs are converted to absolute format (e.g., `https://bruno.verachten.fr/2025/10/30/...`).