### PR TITLE
fix: add newline formatting to blog post template

### DIFF
--- a/.github/workflows/blog-post.yml
+++ b/.github/workflows/blog-post.yml
@@ -14,4 +14,4 @@ jobs:
         with:
           max_post_count: 10
           feed_list: "https://bruno.verachten.fr/feed.xml"
-          template: "- [$title](https://bruno.verachten.fr$url)"
+          template: "- [$title](https://bruno.verachten.fr$url)#newline#"

--- a/.github/workflows/forced_workflow.yml
+++ b/.github/workflows/forced_workflow.yml
@@ -10,4 +10,4 @@ jobs:
         with:
           max_post_count: 10
           feed_list: "https://bruno.verachten.fr/feed.xml"
-          template: "- [$title](https://bruno.verachten.fr$url)"
+          template: "- [$title](https://bruno.verachten.fr$url)#newline#"


### PR DESCRIPTION
## Summary
- Adds newline formatting to the custom blog post template

## Problem
The custom template without newlines caused all blog posts to be concatenated on a single line, making the README difficult to read.

## Solution
Add `#newline#` placeholder to the template which the blog-post-workflow will convert to actual newlines.

## Result
Each blog post will appear on its own line while maintaining absolute URLs.