### PR TITLE
fix: use correct $newline variable in template

### DIFF
--- a/.github/workflows/blog-post.yml
+++ b/.github/workflows/blog-post.yml
@@ -14,4 +14,4 @@ jobs:
         with:
           max_post_count: 10
           feed_list: "https://bruno.verachten.fr/feed.xml"
-          template: "- [$title](https://bruno.verachten.fr$url)#newline#"
+          template: "- [$title](https://bruno.verachten.fr$url)$newline"

--- a/.github/workflows/forced_workflow.yml
+++ b/.github/workflows/forced_workflow.yml
@@ -10,4 +10,4 @@ jobs:
         with:
           max_post_count: 10
           feed_list: "https://bruno.verachten.fr/feed.xml"
-          template: "- [$title](https://bruno.verachten.fr$url)#newline#"
+          template: "- [$title](https://bruno.verachten.fr$url)$newline"


### PR DESCRIPTION
## Summary
- Uses the correct `$newline` variable instead of `#newline#` placeholder

## Problem
The previous attempt used `#newline#` which appeared literally in the output instead of being converted to actual newlines.

## Solution
Use `$newline` which is the documented variable for inserting newlines in the blog-post-workflow template parameter.

## Result
Each blog post will appear on its own line with proper formatting and absolute URLs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub workflow template formatting to use variable expansion for newline handling instead of literal placeholders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->