### PR TITLE
fix: add newline after START comment for first bullet

### DIFF
--- a/.github/workflows/blog-post.yml
+++ b/.github/workflows/blog-post.yml
@@ -15,3 +15,4 @@ jobs:
           max_post_count: 10
           feed_list: "https://bruno.verachten.fr/feed.xml"
           template: "- [$title](https://bruno.verachten.fr$url)$newline"
+          tag_post_pre_newline: true

--- a/.github/workflows/forced_workflow.yml
+++ b/.github/workflows/forced_workflow.yml
@@ -11,3 +11,4 @@ jobs:
           max_post_count: 10
           feed_list: "https://bruno.verachten.fr/feed.xml"
           template: "- [$title](https://bruno.verachten.fr$url)$newline"
+          tag_post_pre_newline: true


### PR DESCRIPTION
## Summary
- Adds `tag_post_pre_newline: true` parameter to both workflows

## Problem
The first blog post was appearing on the same line as the `<!-- BLOG-POST-LIST:START -->` comment, causing its bullet point to not render properly in Markdown.

## Solution
The `tag_post_pre_newline` parameter ensures a newline is inserted after the opening comment tag, allowing all blog posts (including the first one) to render with proper bullet points.

## Result
All blog posts will display with bullets and proper formatting.