### PR TITLE
fix(ci): remove duplicate base URL in blog post links

### DIFF
--- a/.github/workflows/blog-post.yml
+++ b/.github/workflows/blog-post.yml
@@ -14,5 +14,5 @@ jobs:
         with:
           max_post_count: 10
           feed_list: "https://bruno.verachten.fr/feed.xml"
-          template: "- [$title](https://bruno.verachten.fr$url)$newline"
+          template: "- [$title]($url)$newline"
           tag_post_pre_newline: true


### PR DESCRIPTION
## Summary
The blog post workflow template was prepending `https://bruno.verachten.fr` to `$url`, but the Hugo RSS feed already provides absolute URLs. This resulted in broken links like:

`https://bruno.verachten.frhttps//bruno.verachten.fr/2026/03/15/...`

Fix: use `$url` directly since it already contains the full URL.

## Test plan
- [ ] Trigger workflow manually or wait for daily cron
- [ ] Verify README links point to correct single URLs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed blog post hyperlink generation to properly compose full URLs using dynamic parameters instead of hardcoded values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->