### PR TITLE
chore(profile): full rewrite — RISC-V persona, Mastodon/Bluesky, ex-Jenkins

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,39 @@
 ### Hi there 👋
 
-<!--
-**gounthar/gounthar** is a ✨ _special_ ✨ repository because its `README.md` (this file) appears on your GitHub profile.
+Hardware romantic. Open source contributor. Ex-Jenkins contributor.
 
-Here are some ideas to get you started:
--->
-- 🔭 I’m currently working on Continuous Integration for Mobile Development and Jenkins
-- 👯 I’m looking to collaborate on DeviceFarmer
-- 🤔 I’m looking for help with designing add-on boards for SBCs
-- 💬 Ask me about Jenkins, Linux on SBCs, Docker, ARM, RISC-V
-- 📫 How to reach me: poddingue on Twitter/X, and LinkedIn
+I help build community around [XCP-ng](https://xcp-ng.org) and
+[Xen Orchestra](https://xen-orchestra.com) — because hypervisors deserve
+better word-of-mouth than "it's like VMware but free."
+
+Obsessed with RISC-V: running AI inference on boards that cost less than
+a good meal, building Python wheels nobody packaged yet, and occasionally
+breaking things in very instructive ways.
+
+- 🔭 Currently: RISC-V ecosystem, XCP-ng community, whatever SBC landed
+  on my desk this week
+- 🌱 Watching: virtualization, edge computing, and RISC-V quietly converging
+- 💬 Ask me about: Linux, Docker, ARM, RISC-V, XCP-ng, (ex-)Jenkins
+- 📫 Reach me: [Twitter/X](https://twitter.com/poddingue) ·
+  [LinkedIn](https://www.linkedin.com/in/poddingue/) ·
+  [Mastodon](https://mastodon.online/@poddingue) ·
+  [Bluesky](https://bsky.app/profile/poddingue.bsky.social)
 - 😄 Pronouns: He/Him
-- ⚡ Fun fact: Got in love with embedded/handheld hardware when playing with the HP48SX in 1989
+- ⚡ Fun fact: fell in love with embedded hardware playing with an HP48SX
+  in 1989. Still haven't recovered.
 
-Father of two, husband of one, geek in denial, fond of handheld devices since 1989, beekeeper, and permie. #Linux #Android #Docker #ARMV8 #IOT
+Father of two, husband of one, geek in denial, beekeeper, permie.  
+`#Linux` `#RISCV` `#Docker` `#ARM` `#XcpNg`
 
-[![GitHub Streak](https://github-readme-streak-stats-eight.vercel.app/?user=gounthar)]
-![](https://github-readme-streak-stats-eight.vercel.app/?user=gounthar&theme=merko)
+![GitHub Streak](https://github-readme-streak-stats-eight.vercel.app/?user=gounthar&theme=merko)
 
-### Latest Blogs
+### Latest posts
 <!-- BLOG-POST-LIST:START -->
-- [NanoClaw on RISC-V: from “it works on my board” to automated builds](https://bruno.verachten.fr/2026/03/15/nanoclaw-on-risc-v-from-it-works-on-my-board-to-automated-builds/)
+- [NanoClaw on RISC-V: from "it works on my board" to automated builds](https://bruno.verachten.fr/2026/03/15/nanoclaw-on-risc-v-from-it-works-on-my-board-to-automated-builds/)
 - [NanoClaw on RISC-V: Running an AI Agent Runtime on a Banana Pi F3](https://bruno.verachten.fr/2026/03/14/nanoclaw-on-risc-v-running-an-ai-agent-runtime-on-a-banana-pi-f3/)
 - [Benchmarking llama.cpp on SpacemiT K3: RISC-V AI Cores vs Standard RVV &lpar;Part 4&rpar;](https://bruno.verachten.fr/2026/03/12/benchmarking-llama.cpp-on-spacemit-k3-risc-v-ai-cores-vs-standard-rvv-part-4/)
 - [First Words: LLM Inference on RISC-V](https://bruno.verachten.fr/2026/03/11/first-words-llm-inference-on-risc-v/)
-- [The Dependency Rabbit Hole: Why 25 RISC-V Python Wheels Weren’t Enough](https://bruno.verachten.fr/2026/03/11/the-dependency-rabbit-hole-why-25-risc-v-python-wheels-werent-enough/)
+- [The Dependency Rabbit Hole: Why 25 RISC-V Python Wheels Weren't Enough](https://bruno.verachten.fr/2026/03/11/the-dependency-rabbit-hole-why-25-risc-v-python-wheels-werent-enough/)
 - [Building a Python Wheel Factory for RISC-V](https://bruno.verachten.fr/2026/03/10/building-a-python-wheel-factory-for-risc-v/)
 - [Installing XCP-ng on Scaleway Elastic Metal: 30 Hours of Pain, 10 Minutes of Script](https://bruno.verachten.fr/2026/03/05/installing-xcp-ng-on-scaleway-elastic-metal-30-hours-of-pain-10-minutes-of-script/)
 - [Running 100 Wasm Containers on a Raspberry Pi &lpar;with 903 MB of RAM&rpar;](https://bruno.verachten.fr/2026/03/01/running-100-wasm-containers-on-a-raspberry-pi-with-903-mb-of-ram/)


### PR DESCRIPTION
## Summary

- Drop Jenkins-first framing, replaced with persona-driven intro (RISC-V, hardware, community)
- Add XCP-ng / Xen Orchestra community work context
- Replace outdated bullet points (DeviceFarmer, mobile CI) with current focus areas
- Add Mastodon and Bluesky to contact section
- Update LinkedIn URL to `/in/poddingue/`
- Acknowledge Jenkins as "ex-contributor" rather than current work
- Keep fun section: HP48SX 1989, beekeeper, permie
- Remove broken duplicate streak widget; keep themed one
- Rename "Latest Blogs" → "Latest posts"
- Keep existing `BLOG-POST-LIST` entries (auto-updated by CI)

## Test plan
- [ ] Preview renders correctly on GitHub profile
- [ ] All links resolve (Twitter, LinkedIn, Mastodon, Bluesky)
- [ ] Streak widget loads
- [ ] Blog post auto-update CI still functions after section rename

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refreshed profile bio with updated introduction highlighting key interests and technologies.
  * Reorganized profile sections including currently learning, watching, and contact details.
  * Updated featured blog posts listing with latest content.
  * Enhanced visual presentation with improved theme styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->